### PR TITLE
feat: force close

### DIFF
--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -18,7 +18,7 @@ contract LyraVault is Ownable, BaseVault {
   address public lyraRewardRecipient;
 
   // Amount locked for scheduled withdrawals last week;
-  uint128 public lastQueuedWithdrawAmount;
+  uint public lastQueuedWithdrawAmount;
   // % of funds to be used for weekly option purchase
   uint public optionAllocation;
 
@@ -97,12 +97,12 @@ contract LyraVault is Ownable, BaseVault {
 
     strategy.setBoard(boardId);
 
-    (uint lockedBalance, uint queuedWithdrawAmount) = _rollToNextRound(uint(lastQueuedWithdrawAmount));
+    (uint lockedBalance, uint queuedWithdrawAmount) = _rollToNextRound(lastQueuedWithdrawAmount);
 
     vaultState.lockedAmount = uint104(lockedBalance);
     vaultState.lockedAmountLeft = lockedBalance;
     vaultState.roundInProgress = true;
-    lastQueuedWithdrawAmount = uint128(queuedWithdrawAmount);
+    lastQueuedWithdrawAmount = queuedWithdrawAmount;
 
     emit RoundStarted(vaultState.round, uint104(lockedBalance));
   }

--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -89,8 +89,9 @@ contract LyraVault is Ownable, BaseVault {
     emit RoundClosed(vaultState.round, lockAmount);
   }
 
-  /// @dev close the current round, enable user to deposit for the next round
-  function forceClose() external onlyOwner {
+  /// @dev Close the current round, enable user to deposit for the next round
+  //       Can call multiple times before round starts to close all positions
+  function emergencyCloseRound() external onlyOwner {
     require(vaultState.roundInProgress, "round closed");
 
     uint104 lockAmount = vaultState.lockedAmount;
@@ -100,9 +101,7 @@ contract LyraVault is Ownable, BaseVault {
     vaultState.nextRoundReadyTimestamp = block.timestamp + Vault.ROUND_DELAY;
     vaultState.roundInProgress = false;
 
-    // won't be able to close if positions are not settled
-    strategy.forceCloseAll(lyraRewardRecipient);
-
+    strategy.emergencyCloseAll(lyraRewardRecipient);
     emit RoundClosed(vaultState.round, lockAmount);
   }
 

--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -89,6 +89,23 @@ contract LyraVault is Ownable, BaseVault {
     emit RoundClosed(vaultState.round, lockAmount);
   }
 
+  /// @dev close the current round, enable user to deposit for the next round
+  function forceClose() external onlyOwner {
+    require(vaultState.roundInProgress, "round closed");
+
+    uint104 lockAmount = vaultState.lockedAmount;
+    vaultState.lastLockedAmount = lockAmount;
+    vaultState.lockedAmountLeft = 0;
+    vaultState.lockedAmount = 0;
+    vaultState.nextRoundReadyTimestamp = block.timestamp + Vault.ROUND_DELAY;
+    vaultState.roundInProgress = false;
+
+    // won't be able to close if positions are not settled
+    strategy.forceCloseAll(lyraRewardRecipient);
+
+    emit RoundClosed(vaultState.round, lockAmount);
+  }
+
   /// @notice start the next round
   /// @param boardId board id (asset + expiry) for next round.
   function startNextRound(uint boardId) external onlyOwner {

--- a/contracts/interfaces/IStrategy.sol
+++ b/contracts/interfaces/IStrategy.sol
@@ -18,5 +18,7 @@ interface IStrategy {
     address rewardRecipient
   ) external;
 
+  // function forceCloseAll() external;
+
   function returnFundsAndClearStrikes() external;
 }

--- a/contracts/interfaces/IStrategy.sol
+++ b/contracts/interfaces/IStrategy.sol
@@ -18,7 +18,7 @@ interface IStrategy {
     address rewardRecipient
   ) external;
 
-  // function forceCloseAll() external;
+  function forceCloseAll(address lyraRewardRecipient) external;
 
   function returnFundsAndClearStrikes() external;
 }

--- a/contracts/interfaces/IStrategy.sol
+++ b/contracts/interfaces/IStrategy.sol
@@ -18,7 +18,7 @@ interface IStrategy {
     address rewardRecipient
   ) external;
 
-  function forceCloseAll(address lyraRewardRecipient) external;
+  function emergencyCloseAll(address lyraRewardRecipient) external;
 
   function returnFundsAndClearStrikes() external;
 }

--- a/contracts/mocks/MockStrategy.sol
+++ b/contracts/mocks/MockStrategy.sol
@@ -48,7 +48,7 @@ contract MockStrategy is IStrategy {
     address
   ) external {}
 
-  function forceCloseAll(address lyraRewardRecipient) external {}
+  function emergencyCloseAll(address lyraRewardRecipient) external {}
 
   function setMockIsSettled(bool _isSettled) public {
     isSettlted = _isSettled;

--- a/contracts/mocks/MockStrategy.sol
+++ b/contracts/mocks/MockStrategy.sol
@@ -48,6 +48,8 @@ contract MockStrategy is IStrategy {
     address
   ) external {}
 
+  function forceCloseAll(address lyraRewardRecipient) external {}
+
   function setMockIsSettled(bool _isSettled) public {
     isSettlted = _isSettled;
   }

--- a/contracts/strategies/DeltaLongStrategy.sol
+++ b/contracts/strategies/DeltaLongStrategy.sol
@@ -135,6 +135,23 @@ contract DeltaLongStrategy is StrategyBase, IStrategy {
   }
 
   /**
+   * forced to close all out standing positions, and send funds back to vault
+   */
+  function forceCloseAll(address lyraRewardRecipient) external onlyVault {
+    // the vault might not hold enough sUSD to close all positions, will need someone to tapup before doing so.
+    for (uint i = 0; i < activeStrikeIds.length; i++) {
+      uint strikeId = activeStrikeIds[i];
+      OptionPosition memory position = getPositions(_toDynamic(strikeToPositionId[strikeId]))[0];
+      // revert if position state is not settled
+      _closePosition(position, position.amount, 0, type(uint).max, lyraRewardRecipient);
+      delete strikeToPositionId[strikeId];
+      delete lastTradeTimestamp[strikeId];
+    }
+
+    _returnFundsToVaut();
+  }
+
+  /**
    * @dev perform the trade
    * @param strike strike detail
    * @param maxPremium max premium willing to spend for this trade

--- a/contracts/strategies/DeltaShortStrategy.sol
+++ b/contracts/strategies/DeltaShortStrategy.sol
@@ -64,10 +64,6 @@ contract DeltaShortStrategy is StrategyBase, IStrategy {
     strategyDetail = _deltaStrategy;
   }
 
-  ///////////////////
-  // VAULT ACTIONS //
-  ///////////////////
-
   /**
    * @dev set the board id that will be traded for the next round
    * @param boardId lyra board Id.
@@ -77,6 +73,10 @@ contract DeltaShortStrategy is StrategyBase, IStrategy {
     require(_isValidExpiry(board.expiry), "invalid board");
     activeExpiry = board.expiry;
   }
+
+  ///////////////////
+  // VAULT ACTIONS //
+  ///////////////////
 
   /**
    * @dev convert premium in quote asset into collateral asset and send it back to the vault.

--- a/contracts/strategies/DeltaShortStrategy.sol
+++ b/contracts/strategies/DeltaShortStrategy.sol
@@ -243,11 +243,19 @@ contract DeltaShortStrategy is StrategyBase, IStrategy {
 
   /**
    * forced to close all out standing positions, and send funds back to vault
-   * @return done if all the positions are closed out successfully.
    */
-  function forceCloseAll() external onlyVault returns (bool done) {
-    (, , , , , , , bool roundInProgress) = vault.vaultState();
-    require(roundInProgress, "cannot change strategy if round is active");
+  function forceCloseAll(address lyraRewardRecipient) external onlyVault {
+    // the vault might not hold enough sUSD to close all positions, will need someone to tapup before doing so.
+    for (uint i = 0; i < activeStrikeIds.length; i++) {
+      uint strikeId = activeStrikeIds[i];
+      OptionPosition memory position = getPositions(_toDynamic(strikeToPositionId[strikeId]))[0];
+      // revert if position state is not settled
+      _closePosition(position, position.amount, 0, type(uint).max, lyraRewardRecipient);
+      delete strikeToPositionId[strikeId];
+      delete lastTradeTimestamp[strikeId];
+    }
+
+    _returnFundsToVaut();
   }
 
   /**

--- a/contracts/strategies/StrategyBase.sol
+++ b/contracts/strategies/StrategyBase.sol
@@ -113,7 +113,12 @@ contract StrategyBase is VaultAdapter {
   // Trade Parameter Helpers //
   /////////////////////////////
 
-  function _closePosition(
+  /**
+   * @dev Automatically decide between close and forceClose
+   * depending on whether deltaCutoff or tradingCutoff are crossed
+   */
+
+  function _closeOrForceClosePosition(
     OptionPosition memory position,
     uint closeAmount,
     uint minTotalCost,
@@ -138,10 +143,10 @@ contract StrategyBase is VaultAdapter {
     });
 
     TradeResult memory result;
-    if (!_isOutsideDeltaCutoff(position.strikeId)) {
+    if (!_isOutsideDeltaCutoff(position.strikeId) && !_isWithinTradingCutoff(position.strikeId)) {
       result = closePosition(tradeParams);
     } else {
-      // will pay less competitive price to close position
+      // will pay less competitive price to close position but bypasses Lyra delta/trading cutoffs
       result = forceClosePosition(tradeParams);
     }
     require(result.totalCost <= maxTotalCost, "premium paid is above max expected premium");

--- a/contracts/strategies/StrategyBase.sol
+++ b/contracts/strategies/StrategyBase.sol
@@ -123,13 +123,16 @@ contract StrategyBase is VaultAdapter {
   ) internal {
     // closes excess position with premium balance
 
+    // if it's a full close, take out our collateral as well.
+    uint setCollateralTo = position.amount == closeAmount ? 0 : position.collateral;
+
     TradeInputParameters memory tradeParams = TradeInputParameters({
       strikeId: position.strikeId,
       positionId: position.positionId,
       iterations: 3,
       optionType: optionType,
       amount: closeAmount,
-      setCollateralTo: position.collateral,
+      setCollateralTo: setCollateralTo,
       minTotalCost: minTotalCost,
       maxTotalCost: maxTotalCost,
       rewardRecipient: lyraRewardRecipient // set to zero address if don't want to wait for whitelist

--- a/contracts/strategies/StrategyBase.sol
+++ b/contracts/strategies/StrategyBase.sol
@@ -208,7 +208,7 @@ contract StrategyBase is VaultAdapter {
         // revert if position state is not settled
         require(position.state != PositionState.ACTIVE, "cannot clear active position");
         delete strikeToPositionId[strikeId];
-        delete lastTradeTimestamp[i];
+        delete lastTradeTimestamp[strikeId];
       }
       delete activeStrikeIds;
     }

--- a/test/integration-tests/strategies/delta-strategy-covered-call.ts
+++ b/test/integration-tests/strategies/delta-strategy-covered-call.ts
@@ -569,7 +569,7 @@ describe('Covered Call Delta Strategy integration test', async () => {
       const positionId = await strategy.strikeToPositionId(storedStrikeId);
       const [position] = await lyraTestSystem.optionToken.getOptionPositions([positionId]);
 
-      expect(position.amount.eq(baseStrategy.size)).to.be.true;
+      expect(position.amount.eq(strategyDetail.size)).to.be.true;
     });
 
     it('should be able to trade a higher strike if spot price goes up', async () => {
@@ -584,7 +584,7 @@ describe('Covered Call Delta Strategy integration test', async () => {
       const positionId = await strategy.strikeToPositionId(storedStrikeId);
       const [position] = await lyraTestSystem.optionToken.getOptionPositions([positionId]);
 
-      expect(position.amount.eq(baseStrategy.size)).to.be.true;
+      expect(position.amount.eq(strategyDetail.size)).to.be.true;
     });
 
     it('cannot foce close when the price move against our positions.', async () => {

--- a/test/integration-tests/strategies/delta-strategy-covered-call.ts
+++ b/test/integration-tests/strategies/delta-strategy-covered-call.ts
@@ -91,7 +91,7 @@ describe('Covered Call Delta Strategy integration test', async () => {
 
     await lyraTestSystem.optionGreekCache.updateBoardCachedGreeks(boardId);
 
-    // fast forward do vol gwap can work
+    // fast forward so vol GWAP can work
     await lyraEvm.fastForward(600);
   });
 
@@ -277,7 +277,7 @@ describe('Covered Call Delta Strategy integration test', async () => {
       expect(position.collateral.eq(collateralToAdd)).to.be.true;
     });
 
-    it('should revert when user try to trigger another trade during cooldown', async () => {
+    it('should revert when user try to trigger another trade during cool-down', async () => {
       await expect(vault.connect(randomUser).trade(strikes[3])).to.be.revertedWith('min time interval not passed');
     });
 
@@ -302,7 +302,7 @@ describe('Covered Call Delta Strategy integration test', async () => {
     it('should be able to trade a higher strike if spot price goes up', async () => {
       await TestSystem.marketActions.mockPrice(lyraTestSystem, toBN('3125'), 'sETH');
 
-      // triger with new strike (3550)
+      // trigger with new strike (3550)
       await vault.connect(randomUser).trade(strikes[4]);
 
       // check that active strikes are updated
@@ -326,7 +326,7 @@ describe('Covered Call Delta Strategy integration test', async () => {
       const receipt = await vault.depositReceipts(randomUser.address);
       expect(receipt.amount.eq(additionalDepositAmount)).to.be.true;
     });
-    it('fastforward to the expiry', async () => {
+    it('fast-forward to the expiry', async () => {
       await lyraEvm.fastForward(boardParameter.expiresIn);
     });
     it('should revert when closeRound is called before options are settled', async () => {
@@ -356,15 +356,15 @@ describe('Covered Call Delta Strategy integration test', async () => {
       await vault.closeRound();
 
       const susdInStrategyAfter = await susd.balanceOf(strategy.address);
-      const ethdInStrategyAfter = await seth.balanceOf(strategy.address);
-      const ethInValutAfter = await seth.balanceOf(vault.address);
+      const ethInStrategyAfter = await seth.balanceOf(strategy.address);
+      const ethInVaultAfter = await seth.balanceOf(vault.address);
 
       // strategy should be empty after close round
       expect(susdInStrategyAfter.isZero()).to.be.true;
-      expect(ethdInStrategyAfter.isZero()).to.be.true;
+      expect(ethInStrategyAfter.isZero()).to.be.true;
 
       // the vault should get higher than the amount get from settlement, because of the premium
-      expect(ethInValutAfter.sub(ethInVaultBefore).gt(ethInStrategyBefore));
+      expect(ethInVaultAfter.sub(ethInVaultBefore).gt(ethInStrategyBefore));
     });
   });
   describe('start round 2', async () => {
@@ -509,7 +509,7 @@ describe('Covered Call Delta Strategy integration test', async () => {
     });
 
     // don't need to settle options as optionPosition.status = LIQUIDATED
-    it.skip('fastforward to the expiry and settle options', async () => {
+    it.skip('fast-forward to the expiry and settle options', async () => {
       // @notice: the shortCollateral contract won't have enough seth to pay out (settlement) after liquidation.
       //          so we need to top it up.
       await seth.mint(lyraTestSystem.shortCollateral.address, toBN('10'));
@@ -532,15 +532,15 @@ describe('Covered Call Delta Strategy integration test', async () => {
       await vault.closeRound();
 
       const susdInStrategyAfter = await susd.balanceOf(strategy.address);
-      const ethdInStrategyAfter = await seth.balanceOf(strategy.address);
-      const ethInValutAfter = await seth.balanceOf(vault.address);
+      const ethInStrategyAfter = await seth.balanceOf(strategy.address);
+      const ethInVaultAfter = await seth.balanceOf(vault.address);
 
       // strategy should be empty after close round
       expect(susdInStrategyAfter.isZero()).to.be.true;
-      expect(ethdInStrategyAfter.isZero()).to.be.true;
+      expect(ethInStrategyAfter.isZero()).to.be.true;
 
       // the vault should get higher than the amount get from settlement, because of the premium
-      expect(ethInValutAfter.sub(ethInVaultBefore).gt(ethInStrategyBefore));
+      expect(ethInVaultAfter.sub(ethInVaultBefore).gt(ethInStrategyBefore));
     });
   });
   describe('start round 3: stimulate emergency forceClose', async () => {
@@ -575,7 +575,7 @@ describe('Covered Call Delta Strategy integration test', async () => {
     it('should be able to trade a higher strike if spot price goes up', async () => {
       await TestSystem.marketActions.mockPrice(lyraTestSystem, toBN('3125'), 'sETH');
 
-      // triger with new strike (3550)
+      // trigger with new strike (3550)
       await vault.connect(randomUser).trade(strikes[4]);
 
       // check that active strikes are updated
@@ -587,7 +587,7 @@ describe('Covered Call Delta Strategy integration test', async () => {
       expect(position.amount.eq(strategyDetail.size)).to.be.true;
     });
 
-    it('cannot foce close when the price move against our positions.', async () => {
+    it('cannot force close when the price move against our positions.', async () => {
       await TestSystem.marketActions.mockPrice(lyraTestSystem, toBN('3500'), 'sETH');
       await expect(vault.connect(manager).forceClose()).to.be.revertedWith('ERC20: transfer amount exceeds balance');
     });

--- a/test/integration-tests/strategies/delta-strategy-covered-call.ts
+++ b/test/integration-tests/strategies/delta-strategy-covered-call.ts
@@ -490,7 +490,7 @@ describe('Covered Call Delta Strategy integration test', async () => {
       expect(postReduceBal).to.be.lt(preReduceBal);
     });
   });
-  describe('end round2: assuming position got liquidated', async () => {
+  describe('end round 2: assuming position got liquidated', async () => {
     let strikes: BigNumber[];
     let positionId: BigNumber;
     before('set parameters', async () => {
@@ -541,6 +541,63 @@ describe('Covered Call Delta Strategy integration test', async () => {
 
       // the vault should get higher than the amount get from settlement, because of the premium
       expect(ethInValutAfter.sub(ethInVaultBefore).gt(ethInStrategyBefore));
+    });
+  });
+  describe('start round 3: stimulate emergency forceClose', async () => {
+    let strikes: BigNumber[] = [];
+    before('create new board', async () => {
+      await TestSystem.marketActions.mockPrice(lyraTestSystem, toBN('3000'), 'sETH');
+      await TestSystem.marketActions.createBoard(lyraTestSystem, boardParameter);
+      const boards = await lyraTestSystem.optionMarket.getLiveBoards();
+      boardId = boards[0];
+
+      strikes = await lyraTestSystem.optionMarket.getBoardStrikes(boardId);
+    });
+
+    before('start the next round', async () => {
+      await lyraEvm.fastForward(lyraConstants.DAY_SEC);
+      await vault.connect(manager).startNextRound(boardId);
+    });
+
+    it('should trade when delta and vol are within range', async () => {
+      await vault.connect(randomUser).trade(strikes[3]);
+      // active strike is updated
+      const storedStrikeId = await strategy.activeStrikeIds(0);
+      expect(storedStrikeId.eq(strikes[3])).to.be.true;
+
+      // check that position size is correct
+      const positionId = await strategy.strikeToPositionId(storedStrikeId);
+      const [position] = await lyraTestSystem.optionToken.getOptionPositions([positionId]);
+
+      expect(position.amount.eq(baseStrategy.size)).to.be.true;
+    });
+
+    it('should be able to trade a higher strike if spot price goes up', async () => {
+      await TestSystem.marketActions.mockPrice(lyraTestSystem, toBN('3125'), 'sETH');
+
+      // triger with new strike (3550)
+      await vault.connect(randomUser).trade(strikes[4]);
+
+      // check that active strikes are updated
+      const storedStrikeId = await strategy.activeStrikeIds(1);
+      expect(storedStrikeId.eq(strikes[4])).to.be.true;
+      const positionId = await strategy.strikeToPositionId(storedStrikeId);
+      const [position] = await lyraTestSystem.optionToken.getOptionPositions([positionId]);
+
+      expect(position.amount.eq(baseStrategy.size)).to.be.true;
+    });
+
+    it('cannot foce close when the price move against our positions.', async () => {
+      await TestSystem.marketActions.mockPrice(lyraTestSystem, toBN('3500'), 'sETH');
+      await expect(vault.connect(manager).forceClose()).to.be.revertedWith('ERC20: transfer amount exceeds balance');
+    });
+    it('should be able to force close all positions, if price goes in favor of us', async () => {
+      await TestSystem.marketActions.mockPrice(lyraTestSystem, toBN('2500'), 'sETH');
+      const storedStrikeId1 = await strategy.activeStrikeIds(0);
+      const storedStrikeId2 = await strategy.activeStrikeIds(1);
+      await vault.connect(manager).forceClose();
+      expect(await strategy.strikeToPositionId(storedStrikeId1)).to.be.eq(0);
+      expect(await strategy.strikeToPositionId(storedStrikeId2)).to.be.eq(0);
     });
   });
 });

--- a/test/integration-tests/strategies/delta-strategy-long-call.ts
+++ b/test/integration-tests/strategies/delta-strategy-long-call.ts
@@ -409,5 +409,30 @@ describe('Long Call Strategy integration test', async () => {
     it('should revert when trying to reduce a position', async () => {
       await expect(vault.connect(randomUser).reducePosition(positionId, 0)).to.be.revertedWith('not supported');
     });
+
+    it('should be able to force close when the price move down, settled with 0 profit.', async () => {
+      const balanceBefore = (await susd.balanceOf(strategy.address)).add(await susd.balanceOf(vault.address));
+
+      await TestSystem.marketActions.mockPrice(lyraTestSystem, toBN('2500'), 'sETH');
+      const storedStrikeId1 = await strategy.activeStrikeIds(0);
+
+      await vault.connect(manager).forceClose();
+      const balanceAfter = await susd.balanceOf(vault.address);
+
+      expect(await strategy.strikeToPositionId(storedStrikeId1)).to.be.eq(0);
+      expect(balanceAfter).to.be.eq(balanceBefore);
+    });
+    it('should be able to force close when price goes up, settled with less profit', async () => {
+      const balanceBefore = (await susd.balanceOf(strategy.address)).add(await susd.balanceOf(vault.address));
+      await TestSystem.marketActions.mockPrice(lyraTestSystem, toBN('3500'), 'sETH');
+      const storedStrikeId1 = await strategy.activeStrikeIds(0);
+
+      await vault.connect(manager).forceClose();
+
+      const balanceAfter = await susd.balanceOf(vault.address);
+
+      expect(await strategy.strikeToPositionId(storedStrikeId1)).to.be.eq(0);
+      expect(balanceAfter).to.be.gt(balanceBefore);
+    });
   });
 });

--- a/test/integration-tests/strategies/delta-strategy-long-call.ts
+++ b/test/integration-tests/strategies/delta-strategy-long-call.ts
@@ -410,24 +410,24 @@ describe('Long Call Strategy integration test', async () => {
       await expect(vault.connect(randomUser).reducePosition(positionId, 0)).to.be.revertedWith('not supported');
     });
 
-    it('should be able to force close when the price move down, settled with 0 profit.', async () => {
+    it('should be able to emergency close when the price move down, settled with 0 profit.', async () => {
       const balanceBefore = (await susd.balanceOf(strategy.address)).add(await susd.balanceOf(vault.address));
 
       await TestSystem.marketActions.mockPrice(lyraTestSystem, toBN('2500'), 'sETH');
       const storedStrikeId1 = await strategy.activeStrikeIds(0);
 
-      await vault.connect(manager).forceClose();
+      await vault.connect(manager).emergencyCloseRound();
       const balanceAfter = await susd.balanceOf(vault.address);
 
       expect(await strategy.strikeToPositionId(storedStrikeId1)).to.be.eq(0);
       expect(balanceAfter).to.be.eq(balanceBefore);
     });
-    it('should be able to force close when price goes up, settled with less profit', async () => {
+    it('should be able to emergency close when price goes up, settled with less profit', async () => {
       const balanceBefore = (await susd.balanceOf(strategy.address)).add(await susd.balanceOf(vault.address));
       await TestSystem.marketActions.mockPrice(lyraTestSystem, toBN('3500'), 'sETH');
       const storedStrikeId1 = await strategy.activeStrikeIds(0);
 
-      await vault.connect(manager).forceClose();
+      await vault.connect(manager).emergencyCloseRound();
 
       const balanceAfter = await susd.balanceOf(vault.address);
 


### PR DESCRIPTION
resolve #19 

Currently still letting the owner being the only one with permission to do a forceClose. We should have a more detailed discussion about adding different roles across all functionalities

- [x] forceClose implemented for short vault
- [x] forceClose implemented for long vault
