### PR TITLE
fix(tests): include typechain definitions folder to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,6 @@
     "outDir": "dist",
     "resolveJsonModule": true
   },
-  "include": ["./scripts", "./test"],
+  "include": ["./scripts", "./test", "./typechain-types"],
   "files": ["./hardhat.config.ts"]
 }


### PR DESCRIPTION
Currently tests are failing with the folllowing error

```
An unexpected error occurred:

test/integration-tests/strategies/delta-strategy-covered-call.ts:10:58 - error TS2307: Cannot find module '../../../typechain-types' or its corresponding type declarations.

10 import { DeltaShortStrategy, LyraVault, MockERC20 } from '../../../typechain-types';
                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~
test/integration-tests/strategies/delta-strategy-covered-call.ts:14:8 - error TS2307: Cannot find module '../../../typechain-types/DeltaShortStrategy' or its corresponding type declarations.

14 } from '../../../typechain-types/DeltaShortStrategy';
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I did include typechain definitions in tsconfig and now the tests are passing