### PR TITLE
prevent closeRound if round in progress or board not expired

### DIFF
--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -1,6 +1,6 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
-
+import "hardhat/console.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -76,7 +76,7 @@ contract LyraVault is Ownable, BaseVault {
 
   /// @dev close the current round, enable user to deposit for the next round
   function closeRound() external {
-    require(strategy.activeExpiry < block.timestamp, "cannot close round if board not expired");
+    require(strategy.activeExpiry() < block.timestamp, "cannot close round if board not expired");
     require(vaultState.roundInProgress, "round closed");
 
     uint104 lockAmount = vaultState.lockedAmount;
@@ -111,7 +111,7 @@ contract LyraVault is Ownable, BaseVault {
   /// @notice start the next round
   /// @param boardId board id (asset + expiry) for next round.
   function startNextRound(uint boardId) external onlyOwner {
-    require(!vaultState.roundInProgress, "round opened");
+    require(!vaultState.roundInProgress, "round in progress");
     require(block.timestamp > vaultState.nextRoundReadyTimestamp, "CD");
 
     strategy.setBoard(boardId);

--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -1,6 +1,5 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
-import "hardhat/console.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/core/LyraVault.sol
+++ b/contracts/core/LyraVault.sol
@@ -76,6 +76,9 @@ contract LyraVault is Ownable, BaseVault {
 
   /// @dev close the current round, enable user to deposit for the next round
   function closeRound() external {
+    require(strategy.activeExpiry < block.timestamp, "cannot close round if board not expired");
+    require(vaultState.roundInProgress, "round closed");
+
     uint104 lockAmount = vaultState.lockedAmount;
     vaultState.lastLockedAmount = lockAmount;
     vaultState.lockedAmountLeft = 0;

--- a/contracts/interfaces/IStrategy.sol
+++ b/contracts/interfaces/IStrategy.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.9;
 
 interface IStrategy {
+  function activeExpiry() external returns (uint);
+
   function setBoard(uint boardId) external;
 
   function doTrade(uint strikeId, address rewardRecipient)

--- a/contracts/mocks/MockStrategy.sol
+++ b/contracts/mocks/MockStrategy.sol
@@ -14,6 +14,7 @@ contract MockStrategy is IStrategy {
   bool public isSettlted;
 
   uint public boardId;
+  uint public activeExpiry;
 
   constructor(IERC20Detailed _premiumToken, IERC20Detailed _collateralToken) {
     collateral = _collateralToken;

--- a/test/integration-tests/strategies/delta-strategy-covered-call.ts
+++ b/test/integration-tests/strategies/delta-strategy-covered-call.ts
@@ -519,6 +519,9 @@ describe('Covered Call Delta Strategy integration test', async () => {
     });
 
     it('should be able to close closeRound after settlement', async () => {
+      await lyraEvm.fastForward(boardParameter.expiresIn);
+      await lyraTestSystem.optionMarket.settleExpiredBoard(boardId);
+
       const ethInVaultBefore = await seth.balanceOf(vault.address);
       const ethInStrategyBefore = await seth.balanceOf(strategy.address);
       const susdInStrategyBefore = await susd.balanceOf(strategy.address);

--- a/test/unit-tests/core/vault-shares.ts
+++ b/test/unit-tests/core/vault-shares.ts
@@ -188,9 +188,6 @@ describe('Unit test: share calculating for pending deposit and withdraw', async 
 
   describe('round 2: vault makes profit', async () => {
     describe('start the second round', async () => {
-      it('should be able to close the previous round', async () => {
-        await vault.connect(owner).closeRound();
-      });
       it('stimulate time pass', async () => {
         await ethers.provider.send('evm_increaseTime', [86400]);
         await ethers.provider.send('evm_mine', []);

--- a/test/unit-tests/core/vault.ts
+++ b/test/unit-tests/core/vault.ts
@@ -29,8 +29,6 @@ describe('Unit test: Basic LyraVault flow', async () => {
   const managementFee = 1 * FEE_MULTIPLIER; // 1% fee
   const initCap = parseEther('50');
 
-  let totalDeposit: BigNumber;
-
   // mocked premium in USD and ETH
   const roundPremiumSUSD = parseUnits('50');
   const roundPremiumInEth = parseEther('0.01');
@@ -181,10 +179,6 @@ describe('Unit test: Basic LyraVault flow', async () => {
   });
 
   describe('start the second round', async () => {
-    it('should be able to close the previous round', async () => {
-      totalDeposit = await seth.balanceOf(vault.address);
-      await vault.connect(owner).closeRound();
-    });
     it('should revert if startNextRound is called by arbitrary user', async () => {
       const wrongRoundId = 1000;
       await expect(vault.connect(anyone).startNextRound(wrongRoundId)).to.be.revertedWith(
@@ -222,7 +216,7 @@ describe('Unit test: Basic LyraVault flow', async () => {
     });
 
     it('should revert if trying to start the next round without closing the round', async () => {
-      await expect(vault.startNextRound(0)).to.be.revertedWith('round opened');
+      await expect(vault.startNextRound(0)).to.be.revertedWith('round in progress');
     });
 
     it('should close the current round', async () => {
@@ -256,7 +250,7 @@ describe('Unit test: Basic LyraVault flow', async () => {
       const roundPerformanceFee = roundPremiumInEth.mul(performanceFee).div(100 * FEE_MULTIPLIER);
 
       const weeklyManagementFee = await vault.managementFee();
-      const roundManagementFee = totalDeposit
+      const roundManagementFee = depositAmount
         .add(roundPremiumInEth)
         .mul(weeklyManagementFee)
         .div(100 * FEE_MULTIPLIER);


### PR DESCRIPTION
1. LyraVault.sol - currently, closeRound() can be called by anyone and end the round before the vault can make any trades. Adding a require to ensure activeExpiry < timestamp to make sure round can't be closed until expiry is over. 
2. LyraVault.sol - currently, closeRound() can be called continuously, thus incrementing vaultState.nextRoundReadyTimestamp. Adding a check to ensure only in progress rounds can be closed. 